### PR TITLE
Fix header logo to use Bin to Better wordmark

### DIFF
--- a/html-site/cookie-policy.html
+++ b/html-site/cookie-policy.html
@@ -18,7 +18,7 @@
         <div class="logo">
           <a href="/"
             ><img
-              src="/images/support-bintobetter.webp"
+              src="/images/pdf/page-17-xref-69.png"
               alt="BinToBetter Logo"
               height="50"
           /></a>

--- a/html-site/index.html
+++ b/html-site/index.html
@@ -57,7 +57,7 @@
     <link
       rel="preload"
       as="image"
-      href="/images/support-bintobetter.webp"
+      href="/images/pdf/page-17-xref-69.png"
       fetchpriority="high"
     />
 
@@ -80,7 +80,7 @@
         <div class="logo">
           <a href="/#hero">
             <img
-              src="/images/support-bintobetter.webp"
+              src="/images/pdf/page-17-xref-69.png"
               alt="BinToBetter Logo"
               width="200"
               height="50"

--- a/html-site/privacy-policy.html
+++ b/html-site/privacy-policy.html
@@ -18,7 +18,7 @@
         <div class="logo">
           <a href="/"
             ><img
-              src="/images/support-bintobetter.webp"
+              src="/images/pdf/page-17-xref-69.png"
               alt="BinToBetter Logo"
               height="50"
           /></a>

--- a/html-site/terms-of-service.html
+++ b/html-site/terms-of-service.html
@@ -77,7 +77,7 @@
         <div class="logo">
           <a href="/"
             ><img
-              src="/images/support-bintobetter.webp"
+              src="/images/pdf/page-17-xref-69.png"
               alt="BinToBetter Logo"
               height="50"
           /></a>


### PR DESCRIPTION
The header was still using the wrong image asset (showing a photo instead of the Bin to Better wordmark).

Changes:
- Point the header logo (and preload) to the same Bin to Better wordmark image used in the hero section: /images/pdf/page-17-xref-69.png.
- Apply the same header logo fix to policy pages for consistent branding.

Testing:
- 
pm run test (Playwright): 9 passed, 1 skipped.