### PR TITLE
fix: block unsupported eslint and typescript majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
       - dependency-name: 'eslint'
         update-types:
           - 'version-update:semver-major'
+      - dependency-name: 'typescript'
+        update-types:
+          - 'version-update:semver-major'
     groups:
       # Group all npm production dependencies together
       # Note: Major version updates are excluded and handled individually


### PR DESCRIPTION
## Summary`n- tell Dependabot to ignore unsupported eslint and typescript major bumps until the current Next lint stack supports them`n- prevent recurring non-mergeable toolchain major bot PRs in this repo